### PR TITLE
reference site in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pokeclick
 
+https://djkean.github.io/pokeclick/
+
 ## resources
 
 - https://pokeapi.co


### PR DESCRIPTION
easy for people to quickly jump from the repository page -> the site hosted on github pages